### PR TITLE
CMake Config file: Fix LIBAPPIMAGE_LIBRARIES & LIBAPPIMAGE_INCLUDE_DIRS

### DIFF
--- a/cmake/libappimageConfig.cmake.in
+++ b/cmake/libappimageConfig.cmake.in
@@ -3,13 +3,20 @@
 #  LIBAPPIMAGE_INCLUDE_DIRS - include directories for LIBAPPIMAGE
 #  LIBAPPIMAGE_LIBRARIES    - libraries to link against
 
+@PACKAGE_INIT@
+
 # Compute paths
 get_filename_component(LIBAPPIMAGE_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-set(LIBAPPIMAGE_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
 
 # Our library dependencies (contains definitions for IMPORTED targets)
 include("${LIBAPPIMAGE_CMAKE_DIR}/libappimageTargets.cmake")
 
+# TODO: while we check here for the libs with pkgconfig,
+# we do not create here the respective targets as used
+# in the link interface of the exported libappimage* targets
+# Those target names need to be either mapped here to those
+# pkg_check_modules(IMPORTED_TARGET) creates or changed
+# in the libappimage buildsystem to the original ones.
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GLIB REQUIRED glib-2.0)
 pkg_check_modules(GIO REQUIRED gio-2.0)
@@ -17,9 +24,5 @@ pkg_check_modules(ZLIB REQUIRED zlib)
 pkg_check_modules(CAIRO REQUIRED cairo)
 pkg_check_modules(OPENSSL REQUIRED openssl)
 
-find_library(LIBAPPIMAGE_SHARED_PATH
-    NAMES appimage
-    HINTS "${CMAKE_PREFIX_PATH}"
-)
-
-set(LIBAPPIMAGE_LIBRARIES ${LIBAPPIMAGE_SHARED_PATH})
+get_target_property(LIBAPPIMAGE_INCLUDE_DIRS libappimage INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property(LIBAPPIMAGE_LIBRARIES libappimage LOCATION)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,11 +18,13 @@ add_subdirectory(libappimage)
 # (this registers the build-tree with a global CMake-registry)
 export(PACKAGE libappimage)
 
+include(CMakePackageConfigHelpers)
+
 # Create the AppImageConfig.cmake and AppImageConfigVersion files
-configure_file(
+configure_package_config_file(
     "${PROJECT_SOURCE_DIR}/cmake/libappimageConfig.cmake.in"
     "${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/libappimageConfig.cmake"
-    @ONLY
+    INSTALL_DESTINATION  "lib/cmake/libappimage"
 )
 # ... for both
 configure_file(


### PR DESCRIPTION
LIBAPPIMAGE_INCLUDE_DIRS used to not be set at all, as "CONF_INCLUDE_DIRS"
was no-where defined.
And using find_library(NAMES appimage) to locate the library flaws the
principle idea of the CMake Config file to know precisely where (at least
relatively) the respective library file is.

Using CMakePackageConfigHelpers cares for things like relocatability.