### PR TITLE
Replace g_rename usages by move_file.

### DIFF
--- a/src/libappimage/desktop_integration.c
+++ b/src/libappimage/desktop_integration.c
@@ -4,6 +4,7 @@
 #include "desktop_integration.h"
 #include "appimage_handler.h"
 #include "appimage/appimage.h"
+#include "libappimage_private.h"
 
 extern const char* vendorprefix;
 
@@ -530,7 +531,7 @@ bool move_diricon_as_app_icon(const char* tempdir_path, const char* user_data_di
 
     char* source_path = g_build_path("/", tempdir_path, ".DirIcon", NULL);
 
-    success = g_rename(source_path, target_path) == 0;
+    success = move_file(source_path, target_path);
     if (!success)
         g_warning("Unable to move icon file from %s to %s", source_path, target_path);
 
@@ -579,7 +580,7 @@ bool move_icon_file(const char* user_data_dir, const char* appimage_path_md5, co
         succeed = false;
     }
 
-    if (g_rename(path, target_path) == -1) {
+    if (!move_file(path, target_path)) {
         g_warning("Unable to move icon to: %s\n", target_path);
         succeed = false;
     }
@@ -673,7 +674,7 @@ bool move_desktop_file(const char* tempdir_path, const char* user_data_dir, cons
     free(target_desktop_filename);
     free(target_dir_path);
 
-    succeed = g_rename(desktop_file_path, target_desktop_file_path) == 0;
+    succeed = move_file(desktop_file_path, target_desktop_file_path);
 
     free(desktop_file_path);
     free(target_desktop_file_path);

--- a/src/libappimage/libappimage.c
+++ b/src/libappimage/libappimage.c
@@ -1774,8 +1774,9 @@ int appimage_unregister_in_system(const char *path, bool verbose)
     return 0;
 }
 
-void move_file(const char *source, const char *target) {
+bool move_file(const char* source, const char* target) {
     g_type_init();
+    bool succeed = true;
     GError *error = NULL;
     GFile *icon_file = g_file_new_for_path(source);
     GFile *target_file = g_file_new_for_path(target);
@@ -1783,11 +1784,14 @@ void move_file(const char *source, const char *target) {
 #ifdef STANDALONE
         fprintf(stderr, "Error moving file: %s\n", error->message);
 #endif
+        succeed = false;
         g_clear_error (&error);
     }
 
     g_object_unref(icon_file);
     g_object_unref(target_file);
+
+    return succeed;
 }
 
 struct extract_appimage_file_command_data {

--- a/src/libappimage/libappimage_private.h
+++ b/src/libappimage/libappimage_private.h
@@ -1,0 +1,1 @@
+bool move_file(const char* source, const char* target);


### PR DESCRIPTION
g_rename tries to create hard links which are not possible between different file systems, therefore our own implementation of move_file is used.