### PR TITLE
Add default .png extension when using the .DirIcon 

### DIFF
--- a/src/libappimage/desktop_integration.c
+++ b/src/libappimage/desktop_integration.c
@@ -526,7 +526,8 @@ bool move_diricon_as_app_icon(const char* tempdir_path, const char* user_data_di
     char* target_dir_path = g_build_path("/", user_data_dir, "icons/hicolor/32x32/apps/", NULL);
     g_mkdir_with_parents(target_dir_path, S_IRWXU);
 
-    char* new_icon_name = g_strjoin("_", vendorprefix, appimage_path_md5, icon_name, NULL);
+    char* icon_name_with_extension = g_strjoin("", icon_name, ".png", NULL);
+    char* new_icon_name = g_strjoin("_", vendorprefix, appimage_path_md5, icon_name_with_extension, NULL);
     char* target_path = g_build_path("/", target_dir_path, new_icon_name, NULL);
 
     char* source_path = g_build_path("/", tempdir_path, ".DirIcon", NULL);
@@ -538,6 +539,7 @@ bool move_diricon_as_app_icon(const char* tempdir_path, const char* user_data_di
     g_free(source_path);
     g_free(target_path);
     g_free(new_icon_name);
+    g_free(icon_name_with_extension);
     g_free(target_dir_path);
 
     return success;

--- a/tests/test_desktop_integration.cpp
+++ b/tests/test_desktop_integration.cpp
@@ -173,7 +173,7 @@ TEST_F(DesktopIntegrationTests, move_files_to_user_data_dir) {
 
     /** Validate that the icon was copied */
     path = g_strjoin("", user_dir_path.c_str(), "/icons/hicolor/32x32/apps/appimagekit_", md5sum,
-                     "_utilities-terminal",
+                     "_utilities-terminal.png",
                      NULL);
     ASSERT_TRUE(g_file_test(path, G_FILE_TEST_EXISTS));
     free(path);


### PR DESCRIPTION
Add default .png extension when using the .DirIcon for the desktop integration