### PR TITLE
Support extraction of SQUASHFS_LREG_TYPE files

### DIFF
--- a/src/libappimage/libappimage.c
+++ b/src/libappimage/libappimage.c
@@ -306,7 +306,7 @@ gchar **squash_get_matching_files_install_icons_and_mime_data(sqfs* fs, char* pa
                     fprintf(stderr, "squash_get_matching_files found: %s\n", trv.path);
                 g_ptr_array_add(array, g_strdup(trv.path));
                 gchar *dest = NULL;
-                if(inode.base.inode_type == SQUASHFS_REG_TYPE) {
+                if(inode.base.inode_type == SQUASHFS_REG_TYPE || inode.base.inode_type == SQUASHFS_LREG_TYPE) {
                     if(g_str_has_prefix(trv.path, "usr/share/icons/") || g_str_has_prefix(trv.path, "usr/share/pixmaps/") || (g_str_has_prefix(trv.path, "usr/share/mime/") && g_str_has_suffix(trv.path, ".xml"))){
                         char* data_home = xdg_data_home();
                         gchar *path = replace_str(trv.path, "usr/share", data_home);

--- a/src/libappimage/type2.c
+++ b/src/libappimage/type2.c
@@ -112,7 +112,7 @@ bool appimage_type2_extract_file_following_symlinks(sqfs* fs, sqfs_inode* inode,
         return false;
     }
 
-    if (inode->base.inode_type != SQUASHFS_REG_TYPE) {
+    if (inode->base.inode_type != SQUASHFS_REG_TYPE && inode->base.inode_type != SQUASHFS_LREG_TYPE) {
 #ifdef STANDALONE
         fprintf(stderr, "WARNING: Unable to extract file of type %d", inode->base.inode_type);
 #endif
@@ -189,7 +189,7 @@ bool type2_read_file_into_buf(struct appimage_handler* handler, void* traverse, 
         return false;
     }
 
-    if (inode.base.inode_type != SQUASHFS_REG_TYPE) {
+    if (inode.base.inode_type != SQUASHFS_REG_TYPE && inode.base.inode_type != SQUASHFS_LREG_TYPE) {
 #ifdef STANDALONE
         fprintf(stderr, "WARNING: Unable to extract file of type %d", inode->base.inode_type);
 #endif


### PR DESCRIPTION
Fix for https://github.com/TheAssassin/AppImageLauncher/issues/97
`SQUASHFS_L` types strikes again. This PR fix add `SQUASHFS_LREG_TYPE` support wherever `SQUASHFS_REG_TYPE` is used