### PR TITLE
Properly handle links while extracting files 

### DIFF
--- a/include/appimage/appimage.h
+++ b/include/appimage/appimage.h
@@ -49,7 +49,7 @@ int appimage_register_in_system(const char *path, bool verbose);
 int appimage_unregister_in_system(const char *path, bool verbose);
 
 /* Extract a given file from the appimage following the symlinks until a concrete file is found */
-void appimage_extract_file_following_symlinks(const char* appimage_file_path, const char* file_path, const char* target_dir);
+void appimage_extract_file_following_symlinks(const char* appimage_file_path, const char* file_path, const char* target_file_path);
 
 /* Read a given file from the AppImage into a freshly allocated buffer following symlinks
  * Buffer must be free()d after usage

--- a/src/libappimage/libappimage.c
+++ b/src/libappimage/libappimage.c
@@ -1797,6 +1797,7 @@ bool move_file(const char* source, const char* target) {
 struct extract_appimage_file_command_data {
     const char *path;
     const char *destination;
+    char *link;
 };
 struct read_appimage_file_into_buffer_command_data {
     char* file_path;
@@ -1808,11 +1809,15 @@ struct read_appimage_file_into_buffer_command_data {
 
 void extract_appimage_file_command(void* handler_data, void* entry_data, void* user_data) {
     appimage_handler* h = handler_data;
-    const struct extract_appimage_file_command_data const* params = user_data;
+    struct extract_appimage_file_command_data * params = user_data;
 
     char* filename = h->get_file_name(h, entry_data);
-    if (strcmp(params->path, filename) == 0)
+    if (strcmp(params->path, filename) == 0) {
+        params->link = h->get_file_link(handler_data, entry_data);
+
         h->extract_file(h, entry_data, params->destination);
+    }
+
 
     free(filename);
 }
@@ -1836,13 +1841,6 @@ void read_appimage_file_into_buffer_command(void* handler_data, void* entry_data
 
 
     free(filename);
-}
-
-void extract_appimage_file(appimage_handler *h, const char *path, const char *destination) {
-    struct extract_appimage_file_command_data data;
-    data.path = path;
-    data.destination = destination;
-    h->traverse(h, extract_appimage_file_command, &data);
 }
 
 void extract_appimage_icon_command(void *handler_data, void *entry_data, void *user_data) {
@@ -1890,12 +1888,36 @@ void appimage_create_thumbnail(const char *appimage_file_path, bool verbose) {
 
 }
 
-void appimage_extract_file_following_symlinks(const gchar* appimage_file_path, const char* file_path, const char* target_dir) {
-    appimage_handler handler = create_appimage_handler(appimage_file_path);
+void appimage_extract_file_following_symlinks(const gchar* appimage_file_path, const char* file_path,
+                                              const char* target_file_path) {
 
-    extract_appimage_file(&handler, file_path, target_dir);
+    struct extract_appimage_file_command_data data;
+    data.link = strdup(file_path);
+    data.destination = target_file_path;
 
-    // TODO: free handler?
+    bool looping = false;
+    GSList* visited_entries = NULL;
+
+    do {
+        visited_entries = g_slist_prepend(visited_entries, data.link);
+        data.path = data.link;
+        data.link = NULL;
+
+        appimage_handler handler = create_appimage_handler(appimage_file_path);
+        handler.traverse(&handler, extract_appimage_file_command, &data);
+
+        if (data.link) {
+            if (data.link && visited_entries &&
+                g_slist_find_custom(visited_entries, data.link, (GCompareFunc) strcmp))
+                looping = true;
+
+            g_remove(target_file_path);
+        }
+
+    } while (data.link && !looping);
+
+    if (visited_entries)
+        g_slist_free_full(visited_entries, free);
 }
 
 bool appimage_read_file_into_buffer_following_symlinks(const char* appimage_file_path, const char* file_path,
@@ -1926,7 +1948,7 @@ bool appimage_read_file_into_buffer_following_symlinks(const char* appimage_file
         appimage_handler handler = create_appimage_handler(appimage_file_path);
         handler.traverse(&handler, &read_appimage_file_into_buffer_command, &data);
 
-        // Find looks
+        // Find loops
         if (data.link_path && visited_entries &&
             g_slist_find_custom(visited_entries, data.link_path, (GCompareFunc) strcmp))
                 data.success = false;

--- a/src/libappimage/libappimage.c
+++ b/src/libappimage/libappimage.c
@@ -1906,17 +1906,16 @@ void appimage_extract_file_following_symlinks(const gchar* appimage_file_path, c
         appimage_handler handler = create_appimage_handler(appimage_file_path);
         handler.traverse(&handler, extract_appimage_file_command, &data);
 
-        if (data.link) {
-            if (data.link && visited_entries &&
-                g_slist_find_custom(visited_entries, data.link, (GCompareFunc) strcmp))
+        if (data.link != NULL) {
+            if (visited_entries != NULL && g_slist_find_custom(visited_entries, data.link, (GCompareFunc) strcmp))
                 looping = true;
 
             g_remove(target_file_path);
         }
 
-    } while (data.link && !looping);
+    } while (data.link != NULL && !looping);
 
-    if (visited_entries)
+    if (visited_entries != NULL)
         g_slist_free_full(visited_entries, free);
 }
 
@@ -1937,7 +1936,7 @@ bool appimage_read_file_into_buffer_following_symlinks(const char* appimage_file
         data.link_path = NULL;
 
         // release any data that could be allocated in previous iterations
-        if (data.out_buffer ) {
+        if (data.out_buffer != NULL) {
             free(data.out_buffer);
             data.out_buffer = NULL;
             data.out_buf_size = 0;
@@ -1949,12 +1948,12 @@ bool appimage_read_file_into_buffer_following_symlinks(const char* appimage_file
         handler.traverse(&handler, &read_appimage_file_into_buffer_command, &data);
 
         // Find loops
-        if (data.link_path && visited_entries &&
+        if (data.link_path != NULL && visited_entries &&
             g_slist_find_custom(visited_entries, data.link_path, (GCompareFunc) strcmp))
                 data.success = false;
     } while (data.success && data.link_path != NULL);
 
-    if (visited_entries)
+    if (visited_entries != NULL)
         g_slist_free_full(visited_entries, free);
 
     if (!data.success) {

--- a/tests/test_libappimage.cpp
+++ b/tests/test_libappimage.cpp
@@ -265,7 +265,24 @@ TEST_F(LibAppImageTest, appimage_read_file_into_buffer_following_hardlinks_type_
     free(buf);
 }
 
-bool test_appimage_is_registered_in_system(const std::string &pathToAppImage, bool integrateAppImage) {
+TEST_F(LibAppImageTest, appimage_extract_file_following_hardlinks_type_1) {
+    const char target_file_path[] = "/tmp/appimage_tmp_file";
+    appimage_extract_file_following_symlinks(appImage_type_1_file_path.c_str(),
+                                             "AppImageExtract.png", target_file_path);
+
+
+    // using EXPECT makes sure the free call is executed
+    EXPECT_TRUE(g_file_test(target_file_path, G_FILE_TEST_EXISTS));
+    EXPECT_TRUE(g_file_test(target_file_path, G_FILE_TEST_IS_REGULAR));
+
+    struct stat stats = {};
+    lstat(target_file_path, &stats);
+    EXPECT_NE(stats.st_size, 0);
+
+    g_remove(target_file_path);
+}
+
+bool test_appimage_is_registered_in_system(const std::string& pathToAppImage, bool integrateAppImage) {
     if (integrateAppImage) {
         EXPECT_EQ(appimage_register_in_system(pathToAppImage.c_str(), false), 0);
     }


### PR DESCRIPTION
Add support to extract hard links on `appimage_extract_file_following_symlinks`
