### PR TITLE
Fix LIBAPPIMAGE_LIBRARIES NOT FOUND

### DIFF
--- a/cmake/libappimageConfig.cmake.in
+++ b/cmake/libappimageConfig.cmake.in
@@ -15,4 +15,4 @@ include(${LIBAPPIMAGE_CMAKE_DIR}/imported_dependencies.cmake)
 include(${LIBAPPIMAGE_CMAKE_DIR}/libappimageTargets.cmake)
 
 get_target_property(LIBAPPIMAGE_INCLUDE_DIRS libappimage INTERFACE_INCLUDE_DIRECTORIES)
-get_target_property(LIBAPPIMAGE_LIBRARIES libappimage IMPORTED_LOCATION)
+get_target_property(LIBAPPIMAGE_LIBRARIES libappimage LOCATION)

--- a/cmake/libappimageConfig.cmake.in
+++ b/cmake/libappimageConfig.cmake.in
@@ -1,7 +1,11 @@
 # - Config file for the AppImage package
-# It defines the following variables
+# Exported Variables
 #  LIBAPPIMAGE_INCLUDE_DIRS - include directories for LIBAPPIMAGE
 #  LIBAPPIMAGE_LIBRARIES    - libraries to link against
+#
+# Exported Targets
+#  - libappimage
+#  - libappimage_shared
 
 @PACKAGE_INIT@
 
@@ -15,4 +19,4 @@ include(${LIBAPPIMAGE_CMAKE_DIR}/imported_dependencies.cmake)
 include(${LIBAPPIMAGE_CMAKE_DIR}/libappimageTargets.cmake)
 
 get_target_property(LIBAPPIMAGE_INCLUDE_DIRS libappimage INTERFACE_INCLUDE_DIRECTORIES)
-get_target_property(LIBAPPIMAGE_LIBRARIES libappimage LOCATION)
+set(LIBAPPIMAGE_LIBRARIES libappimage)

--- a/cmake/libappimageConfig.cmake.in
+++ b/cmake/libappimageConfig.cmake.in
@@ -1,11 +1,11 @@
 # - Config file for the AppImage package
-# Exported Variables
-#  LIBAPPIMAGE_INCLUDE_DIRS - include directories for LIBAPPIMAGE
-#  LIBAPPIMAGE_LIBRARIES    - libraries to link against
-#
 # Exported Targets
 #  - libappimage
 #  - libappimage_shared
+#
+# Exported Variables (DEPRECATED use the exported targets instead)
+#  LIBAPPIMAGE_INCLUDE_DIRS - include directories for LIBAPPIMAGE
+#  LIBAPPIMAGE_LIBRARIES    - libraries to link against
 
 @PACKAGE_INIT@
 


### PR DESCRIPTION
It seems that the CMakePackageConfigHelpers doesn't populate the IMPORTED_LOCATION property of the targets it exports. Therefore we should use the "LOCATION PROPERTY"