### PR TITLE
Use cmake's project() VERSION feature; separate libappimage_SOVERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.4)
 
-project(libappimage)
+project(libappimage VERSION 0.2.0)
+
+# more versioning
+set(libappimage_SOVERSION 0.2)
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
@@ -14,11 +17,6 @@ set(CMAKE_CXX_FLAGS_RELEASE "-Os -DNDEBUG -Wl,--gc-sections")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 
 include(cmake/reproducible_builds.cmake)
-
-# versioning
-set(V_MAJOR 0)
-set(V_MINOR 2)
-set(V_PATCH 0)
 
 include(cmake/tools.cmake)
 include(cmake/dependencies.cmake)

--- a/cmake/libappimageConfigVersion.cmake.in
+++ b/cmake/libappimageConfigVersion.cmake.in
@@ -1,4 +1,4 @@
-set(PACKAGE_VERSION "@V_MAJOR@.@V_MINOR@.@V_PATCH@")
+set(PACKAGE_VERSION "@libappimage_VERSION@")
  
 # Check whether the requested PACKAGE_FIND_VERSION is compatible
 if("${PACKAGE_VERSION}" VERSION_LESS "${PACKAGE_FIND_VERSION}")

--- a/src/libappimage/CMakeLists.txt
+++ b/src/libappimage/CMakeLists.txt
@@ -47,8 +47,8 @@ foreach(target libappimage libappimage_static)
 
     set_property(TARGET libappimage PROPERTY PUBLIC_HEADER ${libappimage_public_header})
 
-    set_property(TARGET libappimage PROPERTY VERSION ${V_MAJOR}.${V_MINOR}.${V_PATCH})
-    set_property(TARGET libappimage PROPERTY SOVERSION ${V_MAJOR})
+    set_property(TARGET libappimage PROPERTY VERSION ${libappimage_VERSION})
+    set_property(TARGET libappimage PROPERTY SOVERSION ${libappimage_SOVERSION})
 endforeach()
 
 


### PR DESCRIPTION
Given that there are ABI breaking changes planned for minor versions
the lib's SOVERSION needs to be decoupled from the major lib version.