### PR TITLE
Restore appimage_get_elf_size implementation on libappimage_share

### DIFF
--- a/include/appimage/appimage_shared.h
+++ b/include/appimage/appimage_shared.h
@@ -38,6 +38,21 @@ char* appimage_hexlify(const char* bytes, size_t numBytes);
  */
 bool appimage_type2_digest_md5(const char* fname, char* digest);
 
+/*
+ * Calculate the size of an ELF file on disk based on the information in its header
+ *
+ * Example:
+ *
+ * ls -l   126584
+ *
+ * Calculation using the values also reported by readelf -h:
+ * Start of section headers	e_shoff		124728
+ * Size of section headers		e_shentsize	64
+ * Number of section headers	e_shnum		29
+ *
+ * e_shoff + ( e_shentsize * e_shnum ) =	126584
+ */
+ssize_t appimage_get_elf_size(const char* fname);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This is required function is required by the AppImageKit runtime target, therefore, we must keep a bare C implementation. 