### PR TITLE
Dont use an appimage as parameter of unregister

### DIFF
--- a/include/appimage/desktop_integration/IntegrationManager.h
+++ b/include/appimage/desktop_integration/IntegrationManager.h
@@ -93,9 +93,9 @@ namespace appimage {
             /**
              * @brief Remove thumbnails according to the FreeDesktop Thumbnail Managing Standard
              * See: https://specifications.freedesktop.org/thumbnail-spec/0.8.0/index.html
-             * @param appImage
+             * @param appImagePath
              */
-            void removeThumbnails(const core::AppImage& appImage);
+            void removeThumbnails(const std::string& appImagePath);
 
 #endif
 

--- a/include/appimage/desktop_integration/IntegrationManager.h
+++ b/include/appimage/desktop_integration/IntegrationManager.h
@@ -55,9 +55,9 @@ namespace appimage {
              *
              * Remove all files created by the registerAppImage function. The files are identified by matching the
              * AppImageId contained in their names. The Id is made from the MD5 checksum of the <appImagePath>.
-             * @param appImage
+             * @param appImagePath
              */
-            void unregisterAppImage(const core::AppImage& appImage);
+            void unregisterAppImage(const std::string& appImagePath);
 
             /**
              * @brief Check whether the AppImage pointed by <appImagePath> has been registered in the system.

--- a/include/appimage/desktop_integration/IntegrationManager.h
+++ b/include/appimage/desktop_integration/IntegrationManager.h
@@ -65,10 +65,10 @@ namespace appimage {
              * Explore XDG_DATA_HOME/applications looking for Destkop Entries files with a file name that matches
              * the current AppImage Id (MD5 checksum of the <appImagePath>)
              *
-             * @param appImage
+             * @param appImagePath
              * @return true if the AppImage is registered, false otherwise.
              */
-            bool isARegisteredAppImage(const core::AppImage& appImage);
+            bool isARegisteredAppImage(const std::string& appImagePath);
 
             /**
              * @brief Check whether the author of an AppImage doesn't want it to be integrated.

--- a/src/libappimage/desktop_integration/IntegrationManager.cpp
+++ b/src/libappimage/desktop_integration/IntegrationManager.cpp
@@ -112,9 +112,9 @@ namespace appimage {
             return true;
         }
 
-        void IntegrationManager::unregisterAppImage(const core::AppImage& appImage) {
+        void IntegrationManager::unregisterAppImage(const std::string& appImagePath) {
             // Generate AppImage Id
-            const auto appImageId = d->generateAppImageId(appImage.getPath());
+            const auto appImageId = d->generateAppImageId(appImagePath);
 
             // remove files with the
             d->removeMatchingFiles(d->xdgDataHome / "applications", appImageId);

--- a/src/libappimage/desktop_integration/IntegrationManager.cpp
+++ b/src/libappimage/desktop_integration/IntegrationManager.cpp
@@ -69,9 +69,9 @@ namespace appimage {
             i.integrate();
         }
 
-        bool IntegrationManager::isARegisteredAppImage(const core::AppImage& appImage) {
+        bool IntegrationManager::isARegisteredAppImage(const std::string& appImagePath) {
             // Generate AppImage Id
-            const auto& appImageId = d->generateAppImageId(appImage.getPath());
+            const auto& appImageId = d->generateAppImageId(appImagePath);
 
             // look for a desktop entry file with the AppImage Id in its name
             bf::path appsPath = d->xdgDataHome / "applications";

--- a/src/libappimage/desktop_integration/IntegrationManager.cpp
+++ b/src/libappimage/desktop_integration/IntegrationManager.cpp
@@ -127,9 +127,9 @@ namespace appimage {
             d->thumbnailer.create(appImage);
         }
 
-        void IntegrationManager::removeThumbnails(const core::AppImage& appImage) {
+        void IntegrationManager::removeThumbnails(const std::string& appImagePath) {
 
-            d->thumbnailer.remove(appImage);
+            d->thumbnailer.remove(appImagePath);
         }
 
 #endif

--- a/src/libappimage/desktop_integration/Thumbnailer.cpp
+++ b/src/libappimage/desktop_integration/Thumbnailer.cpp
@@ -51,10 +51,10 @@ namespace appimage {
             generateLargeSizeThumbnail(canonicalPathMd5, iconsData[largeIconPath]);
         }
 
-        void Thumbnailer::remove(const core::AppImage& appImage) {
+        void Thumbnailer::remove(const std::string& appImagePath) {
             /* Every resource file related with this appimage has the md5 sum of the appimage canonical
              * path in its name, we are going to use this to recreate the file names */
-            std::string canonicalPathMd5 = hashPath(appImage.getPath());
+            std::string canonicalPathMd5 = hashPath(appImagePath);
             bf::path normalThumbnailPath = getNormalThumbnailPath(canonicalPathMd5);
             bf::path largeThumbnailPath = getLargeThumbnailPath(canonicalPathMd5);
 

--- a/src/libappimage/desktop_integration/Thumbnailer.h
+++ b/src/libappimage/desktop_integration/Thumbnailer.h
@@ -51,9 +51,9 @@ namespace appimage {
              * Will find and remove every thumbnail related to the file pointed by the AppImage path. The files will
              * be identified following the rules described in the Full FreeDesktop Thumbnails spec. Which is available
              * at: https://specifications.freedesktop.org/thumbnail-spec/0.8.0/x227.html
-             * @param appImage
+             * @param appImagePath
              */
-            void remove(const core::AppImage& appImage);
+            void remove(const std::string& appImagePath);
 
             virtual ~Thumbnailer();
 

--- a/src/libappimage/libappimage.cpp
+++ b/src/libappimage/libappimage.cpp
@@ -340,12 +340,12 @@ int appimage_unregister_in_system(const char* path, bool verbose) {
 
 /* Check whether AppImage is registered in the system already */
 bool appimage_is_registered_in_system(const char* path) {
-    // To check whether an AppImage has been integrated, we just have to check whether the desktop file is in place
+    if (path == nullptr)
+        return false;
 
     try {
-        AppImage appImage(path);
         IntegrationManager manager;
-        return manager.isARegisteredAppImage(appImage);
+        return manager.isARegisteredAppImage(path);
     } catch (const std::runtime_error& err) {
         libappimageLogger.error() << " at " << __FUNCTION__ << " : " << err.what() << std::endl;
     } catch (...) {

--- a/src/libappimage/libappimage.cpp
+++ b/src/libappimage/libappimage.cpp
@@ -322,7 +322,7 @@ int appimage_unregister_in_system(const char* path, bool verbose) {
     try {
         AppImage appImage(path);
         IntegrationManager manager;
-        manager.unregisterAppImage(appImage);
+        manager.unregisterAppImage(path);
 
 #ifdef LIBAPPIMAGE_THUMBNAILER_ENABLED
         manager.removeThumbnails(appImage);

--- a/src/libappimage/libappimage.cpp
+++ b/src/libappimage/libappimage.cpp
@@ -319,13 +319,15 @@ int appimage_register_in_system(const char* path, bool verbose) {
 
 /* Unregister an AppImage in the system */
 int appimage_unregister_in_system(const char* path, bool verbose) {
+    if (path == nullptr)
+        return 1;
+
     try {
-        AppImage appImage(path);
         IntegrationManager manager;
         manager.unregisterAppImage(path);
 
 #ifdef LIBAPPIMAGE_THUMBNAILER_ENABLED
-        manager.removeThumbnails(appImage);
+        manager.removeThumbnails(path);
 #endif // LIBAPPIMAGE_THUMBNAILER_ENABLED
         return 0;
     } catch (const std::runtime_error& err) {

--- a/tests/libappimage/desktop_integration/TestIntegrationManager.cpp
+++ b/tests/libappimage/desktop_integration/TestIntegrationManager.cpp
@@ -104,8 +104,7 @@ TEST_F(TestIntegrationManager, unregisterAppImage) {
     createStubFile(desployedMimeTypePackageFilePath, "<?xml");
     ASSERT_TRUE(bf::exists(desployedMimeTypePackageFilePath));
 
-    appimage::core::AppImage appImage(appImagePath);
-    manager.unregisterAppImage(appImage);
+    manager.unregisterAppImage(appImagePath);
 
     ASSERT_FALSE(bf::exists(desployedDesktopFilePath));
     ASSERT_FALSE(bf::exists(desployedIconFilePath));

--- a/tests/libappimage/desktop_integration/TestIntegrationManager.cpp
+++ b/tests/libappimage/desktop_integration/TestIntegrationManager.cpp
@@ -56,8 +56,7 @@ TEST_F(TestIntegrationManager, isARegisteredAppImage) {
     std::string appImagePath = TEST_DATA_DIR "Echo-x86_64.AppImage";
     IntegrationManager manager(userDirPath.string());
 
-    appimage::core::AppImage appImage(appImagePath);
-    ASSERT_FALSE(manager.isARegisteredAppImage(appImage));
+    ASSERT_FALSE(manager.isARegisteredAppImage(appImagePath));
 
     { // Generate fake desktop entry file
         std::string md5 = appimage::utils::hashPath(appImagePath.c_str());
@@ -68,7 +67,7 @@ TEST_F(TestIntegrationManager, isARegisteredAppImage) {
         ASSERT_TRUE(bf::exists(desployedDesktopFilePath));
     }
 
-    ASSERT_TRUE(manager.isARegisteredAppImage(appImage));
+    ASSERT_TRUE(manager.isARegisteredAppImage(appImagePath));
 }
 
 TEST_F(TestIntegrationManager, shallAppImageBeRegistered) {

--- a/tests/libappimage/desktop_integration/TestThumbnailer.cpp
+++ b/tests/libappimage/desktop_integration/TestThumbnailer.cpp
@@ -91,8 +91,7 @@ TEST_F(TestThumbnailer, remove) {
     ASSERT_TRUE(bf::exists(normalIconPath));
     ASSERT_TRUE(bf::exists(largeIconPath));
 
-    appimage::core::AppImage appImage{appImagePath};
-    thumbnailer.remove(appImage);
+    thumbnailer.remove(appImagePath);
 
     ASSERT_FALSE(bf::exists(normalIconPath));
     ASSERT_FALSE(bf::exists(largeIconPath));


### PR DESCRIPTION
The functions listed behind should not receive an AppImage as parameter because they are required in cases where the AppImage file no longer exists also they only require the AppImage file path to do their job.

It's proposed solution changes their public C++ interface. This is still safe as it's not being used anywhere yet.
 
https://github.com/AppImage/libappimage/blob/0e28032547e1d9dc58e37524917f4c051673e3b5/include/appimage/desktop_integration/IntegrationManager.h#L71

https://github.com/AppImage/libappimage/blob/5739462b2f61b96b0205ae6ce37f0ea694f44c0d/src/libappimage/desktop_integration/IntegrationManager.cpp#L115

https://github.com/AppImage/libappimage/blob/5739462b2f61b96b0205ae6ce37f0ea694f44c0d/src/libappimage/desktop_integration/Thumbnailer.h#L56