### PR TITLE
Remove any file created during the integration process in case of errors

### DIFF
--- a/src/libappimage/desktop_integration/IntegrationManager.cpp
+++ b/src/libappimage/desktop_integration/IntegrationManager.cpp
@@ -66,8 +66,16 @@ namespace appimage {
         }
 
         void IntegrationManager::registerAppImage(const core::AppImage& appImage) {
-            integrator::Integrator i(appImage, d->xdgDataHome.string());
-            i.integrate();
+            try {
+                integrator::Integrator i(appImage, d->xdgDataHome.string());
+                i.integrate();
+            } catch (...) {
+                // Remove any file created during the integration process
+                unregisterAppImage(appImage.getPath());
+
+                // Rethrow
+                throw;
+            }
         }
 
         bool IntegrationManager::isARegisteredAppImage(const std::string& appImagePath) {


### PR DESCRIPTION
In case of error during the desktop integration process, this will remove any files deployed.

Regarding to causing too much overhead to the DE  update mechanism. As the files are removed right after the error is found the DE update mechanism should not even have time to see the changes. It will only notice that the files were removed.

Regarding keeping the old copies of the files already in place. If an AppImage is updated and the new file is somehow broken and causes a failure in the integration it will be a bit pointless to have a desktop entry pointing to a broken AppImage. Also, the old desktop entry may no longer be valid.

Provides a fix for #60.