### PR TITLE
Fix build issues while using system resources

### DIFF
--- a/include/appimage/utils/ResourcesExtractor.h
+++ b/include/appimage/utils/ResourcesExtractor.h
@@ -1,7 +1,10 @@
 #pragma once
 
 // system
+#include <map>
 #include <string>
+#include <vector>
+#include <memory>
 
 // libraries
 #include <appimage/core/AppImage.h>

--- a/src/libappimage/desktop_integration/Thumbnailer.cpp
+++ b/src/libappimage/desktop_integration/Thumbnailer.cpp
@@ -1,6 +1,5 @@
 // system
 #include <sstream>
-#include <fstream>
 
 // libraries
 #include <boost/filesystem.hpp>
@@ -83,7 +82,7 @@ namespace appimage {
             }
 
             // It wasn't possible to generate a thumbnail, therefore the the icon will be written unchanged
-            std::ofstream out(normalThumbnailPath.string());
+            bf::ofstream out(normalThumbnailPath);
             out.write(normalIconData.data(), normalIconData.size());
         }
 
@@ -110,7 +109,7 @@ namespace appimage {
             }
 
             // It wasn't possible to generate a thumbnail, therefore the the icon will be written unchanged
-            std::ofstream out(largeThumbnailPath.string());
+            bf::ofstream out(largeThumbnailPath);
             out.write(largeIconData.data(), largeIconData.size());
             out.close();
         }

--- a/src/libappimage/desktop_integration/Thumbnailer.cpp
+++ b/src/libappimage/desktop_integration/Thumbnailer.cpp
@@ -1,5 +1,6 @@
 // system
 #include <sstream>
+#include <fstream>
 
 // libraries
 #include <boost/filesystem.hpp>
@@ -82,7 +83,7 @@ namespace appimage {
             }
 
             // It wasn't possible to generate a thumbnail, therefore the the icon will be written unchanged
-            bf::ofstream out(normalThumbnailPath);
+            std::ofstream out(normalThumbnailPath.string());
             out.write(normalIconData.data(), normalIconData.size());
         }
 
@@ -109,7 +110,7 @@ namespace appimage {
             }
 
             // It wasn't possible to generate a thumbnail, therefore the the icon will be written unchanged
-            bf::ofstream out(largeThumbnailPath);
+            std::ofstream out(largeThumbnailPath.string());
             out.write(largeIconData.data(), largeIconData.size());
             out.close();
         }

--- a/src/libappimage/utils/IconHandle.cpp
+++ b/src/libappimage/utils/IconHandle.cpp
@@ -1,6 +1,7 @@
 // system
 #include <sstream>
 #include <iostream>
+#include <fstream>
 
 // libraries
 #include <boost/filesystem.hpp>
@@ -391,7 +392,7 @@ namespace appimage {
                 if (output.empty())
                     throw IconHandleError("Unable to transform " + imageFormat + " into " + targetFormat);
 
-                bf::ofstream ofstream(path, std::ios::out | std::ios::binary | std::ios::trunc);
+                std::ofstream ofstream(path.string(), std::ios::out | std::ios::binary | std::ios::trunc);
                 if (ofstream.is_open())
                     ofstream.write(reinterpret_cast<const char*>(output.data()), output.size());
                 else

--- a/src/libappimage/utils/path_utils.cpp
+++ b/src/libappimage/utils/path_utils.cpp
@@ -8,6 +8,8 @@
 #include "path_utils.h"
 #include "hashlib.h"
 
+namespace bf = boost::filesystem;
+
 namespace appimage {
     namespace utils {
         std::string pathToURI(const std::string& path) {
@@ -17,11 +19,11 @@ namespace appimage {
                 return path;
         }
 
-        std::string hashPath(const boost::filesystem::path& path) {
+        std::string hashPath(const bf::path& path) {
             if (path.empty())
                 return {};
 
-            const auto& canonicalPath = boost::filesystem::weakly_canonical(path);
+            const auto& canonicalPath = bf::absolute(path);
 
             if (canonicalPath.empty())
                 return {};

--- a/src/libappimage/utils/resources_extractor/ResourcesExtractor.cpp
+++ b/src/libappimage/utils/resources_extractor/ResourcesExtractor.cpp
@@ -1,6 +1,7 @@
 // system
 #include <map>
 #include <set>
+#include <fstream>
 
 // libraries
 #include <boost/filesystem.hpp>
@@ -102,7 +103,7 @@ namespace appimage {
                     bf::create_directories(parentDirPath);
 
                     // write file contents
-                    bf::ofstream file(deployPath);
+                    std::ofstream file(deployPath.string());
                     file << fileItr.read().rdbuf();
 
                     file.close();


### PR DESCRIPTION
- There were some missing includes in the `ResourcesExtractor` header. It showed up while updating AppImageInfo to libappimage 0.2. Wonder why it didn't show up early in our builds.

- Older boost versions don't provide `bf::ofstream` will be replaced by std::ofstream