### PR TITLE
Don't use boost::filesystem::ofstream

### DIFF
--- a/src/libappimage/desktop_integration/Thumbnailer.cpp
+++ b/src/libappimage/desktop_integration/Thumbnailer.cpp
@@ -82,7 +82,7 @@ namespace appimage {
             }
 
             // It wasn't possible to generate a thumbnail, therefore the the icon will be written unchanged
-            bf::ofstream out(normalThumbnailPath);
+            std::ofstream out(normalThumbnailPath.string());
             out.write(normalIconData.data(), normalIconData.size());
         }
 
@@ -109,7 +109,7 @@ namespace appimage {
             }
 
             // It wasn't possible to generate a thumbnail, therefore the the icon will be written unchanged
-            bf::ofstream out(largeThumbnailPath);
+            std::ofstream out(largeThumbnailPath.string());
             out.write(largeIconData.data(), largeIconData.size());
             out.close();
         }


### PR DESCRIPTION
`boost::filesystem::ofstream` is not present in older versions of boost and will be deprecated in future versions of `boost` as the filesystem module was merged into the std. 

This change was lost in a rebase.
