### PR TITLE
Add static appimage get type

### DIFF
--- a/include/appimage/core/AppImage.h
+++ b/include/appimage/core/AppImage.h
@@ -57,6 +57,12 @@ namespace appimage {
             AppImageFormat getFormat() const;
 
             /**
+             * Inspect the magic bytes of the file to guess the AppImage <FORMAT>
+             * @return AppImage <FORMAT>
+             */
+            static AppImageFormat getFormat(const std::string& path);
+
+            /**
              * Calculate the offset in the AppImage file where is located the payload file system.
              *
              * @return offset where the payload filesystem is located.

--- a/src/libappimage/core/AppImage.cpp
+++ b/src/libappimage/core/AppImage.cpp
@@ -37,6 +37,10 @@ namespace appimage {
             return d->format;
         }
 
+        AppImageFormat AppImage::getFormat(const std::string& path) {
+            return Private::getFormat(path);
+        }
+
         AppImage::Private::Private(const std::string& path) : path(path) {
             format = getFormat(path);
 

--- a/src/libappimage/core/AppImage.cpp
+++ b/src/libappimage/core/AppImage.cpp
@@ -47,15 +47,17 @@ namespace appimage {
         AppImageFormat AppImage::Private::getFormat(const std::string& path) {
             utils::MagicBytesChecker magicBytesChecker(path);
 
+            if (!magicBytesChecker.hasElfSignature())
+                return AppImageFormat::INVALID;
+
             if (magicBytesChecker.hasAppImageType1Signature())
                 return AppImageFormat::TYPE_1;
 
             if (magicBytesChecker.hasAppImageType2Signature())
                 return AppImageFormat::TYPE_2;
 
-            if (magicBytesChecker.hasIso9660Signature() && magicBytesChecker.hasElfSignature()) {
-                std::cerr << "WARNING: " << path << " seems to be a Type 1 AppImage without magic bytes."
-                          << std::endl;
+            if (magicBytesChecker.hasIso9660Signature()) {
+                std::cerr << "WARNING: " << path << " seems to be a Type 1 AppImage without magic bytes." << std::endl;
                 return AppImageFormat::TYPE_1;
             }
 

--- a/src/libappimage/libappimage.cpp
+++ b/src/libappimage/libappimage.cpp
@@ -55,10 +55,9 @@ extern "C" {
 int appimage_get_type(const char* path, bool) {
     typedef std::underlying_type<AppImageFormat>::type utype;
     CATCH_ALL(
-        AppImage appImage(path);
-        return static_cast<utype>(appImage.getFormat());
+        const auto format = AppImage::getFormat(path);
+        return static_cast<utype>(format);
     );
-
     return static_cast<utype>(AppImageFormat::INVALID);
 }
 

--- a/tests/libappimage/TestLibappimage++.cpp
+++ b/tests/libappimage/TestLibappimage++.cpp
@@ -85,6 +85,25 @@ TEST_F(AppImageTests, getFormat) {
                      "/non_existend_file").getFormat(), core::AppImageError);
 }
 
+TEST_F(AppImageTests, getFormatStatic) {
+    ASSERT_EQ(core::AppImage::getFormat(TEST_DATA_DIR
+                  "/AppImageExtract_6-x86_64.AppImage"), core::AppImageFormat::TYPE_1);
+    ASSERT_EQ(core::AppImage::getFormat(TEST_DATA_DIR
+                  "/AppImageExtract_6_no_magic_bytes-x86_64.AppImage"), core::AppImageFormat::TYPE_1);
+    ASSERT_EQ(core::AppImage::getFormat(TEST_DATA_DIR
+                  "/Echo-x86_64.AppImage"), core::AppImageFormat::TYPE_2);
+    ASSERT_EQ(core::AppImage::getFormat(TEST_DATA_DIR
+                  "/appimaged-i686.AppImage"), core::AppImageFormat::TYPE_2);
+    ASSERT_EQ(core::AppImage::getFormat(TEST_DATA_DIR
+                  "/elffile"), core::AppImageFormat::INVALID);
+    ASSERT_EQ(core::AppImage::getFormat(TEST_DATA_DIR
+                  "/minimal.iso"), core::AppImageFormat::INVALID);
+    ASSERT_EQ(core::AppImage::getFormat(TEST_DATA_DIR
+                  "/Cura.desktop"), core::AppImageFormat::INVALID);
+    ASSERT_EQ(core::AppImage::getFormat(TEST_DATA_DIR
+                  "/non_existend_file"), core::AppImageFormat::INVALID);
+}
+
 TEST_F(AppImageTests, getPayloadOffset) {
     ASSERT_EQ(core::AppImage(TEST_DATA_DIR
                   "/AppImageExtract_6-x86_64.AppImage").getPayloadOffset(), 28040);


### PR DESCRIPTION
Adds an static version of `AppImage::getFormat`. 

This is useful for the case in which such method is used only to test whether a given file is an AppImage or not.