### PR TITLE
Catch dlopen errors on libcairo and librsvg and trait them as warnigs

### DIFF
--- a/src/libappimage/desktop_integration/Thumbnailer.cpp
+++ b/src/libappimage/desktop_integration/Thumbnailer.cpp
@@ -13,6 +13,7 @@
 #include "utils/Logger.h"
 #include "utils/IconHandle.h"
 #include "utils/path_utils.h"
+#include "utils/DLHandle.h"
 #include "Thumbnailer.h"
 
 using namespace appimage::utils;
@@ -105,6 +106,10 @@ namespace appimage {
             } catch (const IconHandleError&) {
                 /* we fail to resize the icon because it's in an unknown format or some other reason
                  * we just have left to write it down unchanged and hope for the best. */
+                Logger::warning("Unable to resize the application icon into a 256x256 image, "
+                                "it will be written unchanged.");
+            } catch (const DLHandleError& error) {
+                Logger::warning(error.what());
                 Logger::warning("Unable to resize the application icon into a 256x256 image, "
                                 "it will be written unchanged.");
             }

--- a/src/libappimage/desktop_integration/integrator/Integrator.cpp
+++ b/src/libappimage/desktop_integration/integrator/Integrator.cpp
@@ -19,6 +19,7 @@
 #include <appimage/desktop_integration/exceptions.h>
 #include <appimage/utils/ResourcesExtractor.h>
 #include <constants.h>
+#include <utils/DLHandle.h>
 #include "utils/Logger.h"
 #include "utils/hashlib.h"
 #include "utils/IconHandle.h"
@@ -231,6 +232,9 @@ namespace appimage {
                         icon.save(deployPath.string(), icon.format());
                     } catch (const IconHandleError& er) {
                         Logger::error(er.what());
+                        Logger::error("No icon was generated for: " + appImage.getPath());
+                    }  catch (const DLHandleError& error) {
+                        Logger::error(error.what());
                         Logger::error("No icon was generated for: " + appImage.getPath());
                     }
                 }


### PR DESCRIPTION
This will avoid the whole integration process being stopped if `libcairo`, `librsvg` or `libgobject` are not available. 

Contributes to #104 