### PR TITLE
Add support to register AppImage With Additional Actions to the IntegrationManager

### DIFF
--- a/include/appimage/desktop_integration/IntegrationManager.h
+++ b/include/appimage/desktop_integration/IntegrationManager.h
@@ -52,6 +52,28 @@ namespace appimage {
             void registerAppImage(const core::AppImage& appImage) const;
 
             /**
+             * @brief Register an AppImage in the system adding custom desktop entry actions
+             *
+             * Extract the application main desktop entry, icons and mime type packages. Modifies their content to
+             * properly match the AppImage file location and deploy them into the use XDG_DATA_HOME appending a
+             * prefix to each file. Such prefix is composed as "<vendor id>_<appimage_path_md5>_<old_file_name>"
+             *
+             * The desktop entry actions must follow the specification for additional application actions at https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s11.html.
+             * The map key should be the action identifier and the value the action fields in a plain string i.e.:
+             *
+             *  ```
+             *  std::map<std::string, std::string> additionalApplicationActions = {{"Remove",
+             *                                                    "[Desktop Action Remove]\n"
+             *                                                    "Name=\"Remove application\"\n"
+             *                                                    "Icon=remove\n"
+             *                                                    "Exec=remove-appimage-helper /path/to/the/AppImage\n"}};
+             *```
+             * @param appImage
+             * @param additionalApplicationActions desktop entry actions to be added.
+             */
+            void registerAppImage(const core::AppImage& appImage, std::map<std::string, std::string> additionalApplicationActions) const;
+
+            /**
              * @brief Unregister an AppImage in the system
              *
              * Remove all files created by the registerAppImage function. The files are identified by matching the

--- a/src/libappimage/desktop_integration/IntegrationManager.cpp
+++ b/src/libappimage/desktop_integration/IntegrationManager.cpp
@@ -79,6 +79,21 @@ namespace appimage {
             }
         }
 
+        void IntegrationManager::registerAppImage(const core::AppImage &appImage,
+                                                  std::map<std::string, std::string> additionalApplicationActions) const {
+            try {
+                integrator::Integrator i(appImage, d->xdgDataHome);
+                i.setAdditionalApplicationActions(additionalApplicationActions);
+                i.integrate();
+            } catch (...) {
+                // Remove any file created during the integration process
+                unregisterAppImage(appImage.getPath());
+
+                // Rethrow
+                throw;
+            }
+        }
+
         bool IntegrationManager::isARegisteredAppImage(const std::string& appImagePath) const {
             // Generate AppImage Id
             const auto& appImageId = d->generateAppImageId(appImagePath);

--- a/src/libappimage/desktop_integration/integrator/DesktopEntryEditor.cpp
+++ b/src/libappimage/desktop_integration/integrator/DesktopEntryEditor.cpp
@@ -7,6 +7,8 @@
 #include <XdgUtils/DesktopEntry/DesktopEntryExecValue.h>
 #include <XdgUtils/DesktopEntry/DesktopEntryStringsValue.h>
 #include <XdgUtils/DesktopEntry/DesktopEntryKeyPath.h>
+#include <map>
+#include <utility>
 
 // local
 #include "DesktopEntryEditor.h"
@@ -35,6 +37,8 @@ namespace appimage {
                 setIcons(desktopEntry);
 
                 appendVersionToName(desktopEntry);
+
+                appendApplicationActions(desktopEntry);
 
                 // set identifier
                 desktopEntry.set("Desktop Entry/X-AppImage-Identifier", identifier);
@@ -114,6 +118,10 @@ namespace appimage {
                 }
             }
 
+            void DesktopEntryEditor::setAdditionalApplicationActions(std::map<std::string, std::string> additionalApplicationActions) {
+                DesktopEntryEditor::additionalApplicationActions = std::move(additionalApplicationActions);
+            }
+
             void DesktopEntryEditor::setExecPaths(XdgUtils::DesktopEntry::DesktopEntry& desktopEntry) {
                 // Edit "Desktop Entry/Exec"
                 DesktopEntryExecValue execValue(desktopEntry.get("Desktop Entry/Exec"));
@@ -131,6 +139,30 @@ namespace appimage {
                     DesktopEntryExecValue actionExecValue(desktopEntry.get(keyPath));
                     actionExecValue[0] = appImagePath;
                     desktopEntry.set(keyPath, actionExecValue.dump());
+                }
+            }
+
+            void DesktopEntryEditor::appendApplicationActions(XdgUtils::DesktopEntry::DesktopEntry &entry) {
+                for (auto itr = additionalApplicationActions.begin(); itr != additionalApplicationActions.end(); ++itr) {
+                    try {
+                        // validate correctness of the action specification
+                        std::stringstream stringstream(itr->second);
+                        XdgUtils::DesktopEntry::DesktopEntry action(stringstream);
+
+                        // Add action
+                        std::string actionsString = static_cast<std::string>(entry["Desktop Entry/Actions"]);
+                        DesktopEntryStringsValue actions(actionsString);
+
+                        actions.append(itr->first);
+                        entry.set("Desktop Entry/Actions", actions.dump());
+
+                        // Add action definition
+                        for (const auto &path: action.paths())
+                            entry[path] = action.get(path);
+
+                    } catch (const DesktopEntryError &error) {
+                        throw DesktopEntryEditError(std::string("Malformed action: ") + error.what());
+                    }
                 }
             }
         }

--- a/src/libappimage/desktop_integration/integrator/DesktopEntryEditor.h
+++ b/src/libappimage/desktop_integration/integrator/DesktopEntryEditor.h
@@ -40,6 +40,12 @@ namespace appimage {
                 void setIdentifier(const std::string& uuid);
 
                 /**
+                 * Set the application actions that must be appended to the desktop entry on edit.
+                 * @param additionalApplicationActions
+                 */
+                void setAdditionalApplicationActions(std::map<std::string, std::string> additionalApplicationActions);
+
+                /**
                  * Modifies the Desktop Entry according to the set parameters.
                  * @param desktopEntry
                  */
@@ -50,6 +56,7 @@ namespace appimage {
                 std::string vendorPrefix;
                 std::string appImagePath;
                 std::string appImageVersion;
+                std::map<std::string, std::string> additionalApplicationActions;
 
                 /**
                  * Set Exec and TryExec entries in the 'Desktop Entry' and 'Desktop Action' groups pointing to the
@@ -71,6 +78,22 @@ namespace appimage {
                  * If none of both options are valid the names will remain unchanged.
                  */
                 void appendVersionToName(XdgUtils::DesktopEntry::DesktopEntry& entry);
+
+                /**
+                 * @brief Append the additionalApplicationActions to <entry>
+                 * The desktop entry actions must follow the specification for additional application actions at https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s11.html.
+                 * The map key should be the action identifier and the value the action fields in a plain string i.e.:
+                 *
+                 *  std::map<std::string, std::string> applicationActions = {{"Remove",
+                 *                                                    "[Desktop Action Remove]\n"
+                 *                                                    "Name=\"Remove application\"\n"
+                 *                                                    "Icon=remove\n"
+                 *                                                    "Exec=remove-appimage-helper /path/to/the/AppImage\n"}};
+                 *
+                 *
+                 * @param entry
+                 */
+                void appendApplicationActions(XdgUtils::DesktopEntry::DesktopEntry& entry);
             };
 
         }

--- a/src/libappimage/desktop_integration/integrator/Integrator.cpp
+++ b/src/libappimage/desktop_integration/integrator/Integrator.cpp
@@ -47,6 +47,7 @@ namespace appimage {
                 core::AppImage appImage;
                 bf::path xdgDataHome;
                 std::string appImageId;
+                std::map<std::string, std::string> additionalApplicationActions;
 
                 ResourcesExtractor resourcesExtractor;
                 DesktopEntry desktopEntry;
@@ -151,6 +152,10 @@ namespace appimage {
                     editor.setAppImagePath(appImage.getPath());
                     // Set the identifier to be used while prefixing the icon files
                     editor.setIdentifier(md5str);
+
+                    // Set the additional applications actions to be appended
+                    editor.setAdditionalApplicationActions(additionalApplicationActions);
+
                     // Apply changes to the desktop entry
                     editor.edit(entry);
                 }
@@ -301,6 +306,10 @@ namespace appimage {
                 d->deployDesktopEntry();
                 d->deployMimeTypePackages();
                 d->setExecutionPermission();
+            }
+
+            void Integrator::setAdditionalApplicationActions(std::map<std::string, std::string> additionalApplicationActions) {
+                d->additionalApplicationActions = std::move(additionalApplicationActions);
             }
         }
     }

--- a/src/libappimage/desktop_integration/integrator/Integrator.h
+++ b/src/libappimage/desktop_integration/integrator/Integrator.h
@@ -42,6 +42,8 @@ namespace appimage {
                  */
                 void integrate();
 
+                void setAdditionalApplicationActions(std::map<std::string, std::string> additionalApplicationActions);
+
             private:
                 class Priv;
                 std::unique_ptr<Priv> d;   // opaque pointer

--- a/tests/libappimage/desktop_integration/integrator/TestDesktopEntryEditor.cpp
+++ b/tests/libappimage/desktop_integration/integrator/TestDesktopEntryEditor.cpp
@@ -110,3 +110,29 @@ TEST_F(DesktopEntryEditorTests, setIdentifier) {
 
     ASSERT_EQ(entry.get("Desktop Entry/X-AppImage-Identifier"), "uuid");
 }
+
+TEST_F(DesktopEntryEditorTests, setAdditionalApplicationActions) {
+    XdgUtils::DesktopEntry::DesktopEntry entry(originalData);
+
+    DesktopEntryEditor editor;
+    editor.setVendorPrefix("prefix");
+    editor.setIdentifier("uuid");
+    editor.setAppImageVersion("0.1.1");
+    std::map<std::string, std::string> applicationActions = {{"Remove",
+                                                                     "[Desktop Action Remove]\n"
+                                                                     "Name=\"Remove application\"\n"
+                                                                     "Name[es]=\"Eliminar aplicación\"\n"
+                                                                     "Icon=remove\n"
+                                                                     "Exec=remove-appimage-helper /path/to/the/AppImage\n"}};
+
+    editor.setAdditionalApplicationActions(applicationActions);
+    editor.edit(entry);
+
+    ASSERT_EQ(entry.get("Desktop Entry/X-AppImage-Identifier"), "uuid");
+
+    ASSERT_EQ(std::string("Gallery;Create;Remove;"), entry.get("Desktop Entry/Actions"));
+    ASSERT_EQ(std::string("\"Remove application\""), entry.get("Desktop Action Remove/Name"));
+    ASSERT_EQ(std::string("\"Eliminar aplicación\""), entry.get("Desktop Action Remove/Name[es]"));
+    ASSERT_EQ(std::string("remove"), entry.get("Desktop Action Remove/Icon"));
+    ASSERT_EQ(std::string("remove-appimage-helper /path/to/the/AppImage"), entry.get("Desktop Action Remove/Exec"));
+}


### PR DESCRIPTION
Custom applications actions are added by AppImageLauncher and AppImageServices after the desktop file is created. This allows to add such actions at when the desktop file is created.

Implements #137 