### PR TITLE
Add missing fstream include

### DIFF
--- a/src/libappimage/utils/IconHandleCairoRsvg.cpp
+++ b/src/libappimage/utils/IconHandleCairoRsvg.cpp
@@ -1,5 +1,6 @@
 // libraries
 #include <glib-object.h>
+#include <fstream>
 
 // local
 #include "IconHandle.h"


### PR DESCRIPTION
The `fstream` header include was missing and passed unnoticed as it doesn't affected the builds on modern systems. But it does fails on Centos 7.