### PR TITLE
Fix building with GCC 10

### DIFF
--- a/src/patches/squashfuse_dlopen.c
+++ b/src/patches/squashfuse_dlopen.c
@@ -1,5 +1,6 @@
 #include "squashfuse_dlopen.h"
 
+void *libhandle = NULL;
 int have_libloaded = 0;
 
 const char *load_library_errmsg =

--- a/src/patches/squashfuse_dlopen.h
+++ b/src/patches/squashfuse_dlopen.h
@@ -23,9 +23,9 @@
 
 #define LIBNAME "libfuse.so.2"
 
-void *libhandle;
-int have_libloaded;
-const char *load_library_errmsg;
+extern void *libhandle;
+extern int have_libloaded;
+extern const char *load_library_errmsg;
 
 #define LOAD_LIBRARY \
 if (have_libloaded != 1) { \


### PR DESCRIPTION
Fixes the issue that pops up due to the new default `-fno-common` behavior.