### PR TITLE
fix AppImageKit compilation by restoring appimage_get_elf_size()

### DIFF
--- a/include/appimage/appimage_legacy.h
+++ b/include/appimage/appimage_legacy.h
@@ -11,23 +11,6 @@
  */
 
 /*
- * Calculate the size of an ELF file on disk based on the information in its header
- *
- * Example:
- *
- * ls -l   126584
- *
- * Calculation using the values also reported by readelf -h:
- * Start of section headers	e_shoff		124728
- * Size of section headers		e_shentsize	64
- * Number of section headers	e_shnum		29
- *
- * e_shoff + ( e_shentsize * e_shnum ) =	126584
- */
-ssize_t appimage_get_elf_size(const char* fname) __attribute__ ((deprecated));
-
-
-/*
  * Checks whether a type 1 AppImage's desktop file has set Terminal=true.
  *
  * Returns >0 if set, 0 if not set, <0 on errors.

--- a/include/appimage/appimage_shared.h
+++ b/include/appimage/appimage_shared.h
@@ -38,6 +38,22 @@ char* appimage_hexlify(const char* bytes, size_t numBytes);
  */
 bool appimage_type2_digest_md5(const char* fname, char* digest);
 
+/*
+ * Calculate the size of an ELF file on disk based on the information in its header
+ *
+ * Example:
+ *
+ * ls -l   126584
+ *
+ * Calculation using the values also reported by readelf -h:
+ * Start of section headers	e_shoff		124728
+ * Size of section headers		e_shentsize	64
+ * Number of section headers	e_shnum		29
+ *
+ * e_shoff + ( e_shentsize * e_shnum ) =	126584
+ */
+ssize_t appimage_get_elf_size(const char* fname);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libappimage/libappimage_legacy.cpp
+++ b/src/libappimage/libappimage_legacy.cpp
@@ -2,10 +2,6 @@
 #include <appimage/appimage.h>
 
 extern "C" {
-ssize_t appimage_get_elf_size(const char* fname) {
-    return appimage_get_payload_offset(fname);
-}
-
 int appimage_type1_is_terminal_app(const char* path) {
     return appimage_is_terminal_app(path);
 } ;

--- a/src/libappimage_shared/elf.c
+++ b/src/libappimage_shared/elf.c
@@ -117,6 +117,41 @@ static off_t read_elf64(FILE* fd)
 	return sht_end > last_section_end ? sht_end : last_section_end;
 }
 
+ssize_t appimage_get_elf_size(const char* fname) {
+    off_t ret;
+    FILE* fd = NULL;
+    off_t size = -1;
+
+	fd = fopen(fname, "rb");
+	if (fd == NULL) {
+		fprintf(stderr, "Cannot open %s: %s\n",
+			fname, strerror(errno));
+		return -1;
+	}
+	ret = fread(ehdr.e_ident, 1, EI_NIDENT, fd);
+	if (ret != EI_NIDENT) {
+		fprintf(stderr, "Read of e_ident from %s failed: %s\n",
+			fname, strerror(errno));
+		return -1;
+	}
+	if ((ehdr.e_ident[EI_DATA] != ELFDATA2LSB) &&
+		(ehdr.e_ident[EI_DATA] != ELFDATA2MSB)) {
+		fprintf(stderr, "Unkown ELF data order %u\n",
+			ehdr.e_ident[EI_DATA]);
+		return -1;
+	}
+	if (ehdr.e_ident[EI_CLASS] == ELFCLASS32) {
+		size = read_elf32(fd);
+	} else if (ehdr.e_ident[EI_CLASS] == ELFCLASS64) {
+		size = read_elf64(fd);
+	} else {
+		fprintf(stderr, "Unknown ELF class %u\n", ehdr.e_ident[EI_CLASS]);
+		return -1;
+	}
+
+	fclose(fd);
+	return size;
+}
 
 /* Return the offset, and the length of an ELF section with a given name in a given ELF file */
 bool appimage_get_elf_section_offset_and_length(const char* fname, const char* section_name, unsigned long* offset, unsigned long* length) {


### PR DESCRIPTION
Currently AppImageKit can not be compiled with the master branch of libappimage, the build script reports "undefined reference to `appimage_get_elf_size()`".

the `runtime` of AppImageKit can only be linked with `libappimage_shared`, but `appimage_get_elf_size()` is moved into `libappimage` since 4f22f90020f3fc5b9e37a2d5f048eb7fed690a54 . Restoring the function will fix the issue.