### PR TITLE
Fix code warnings, upgrade xz to latest stable version

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -30,8 +30,8 @@ if(NOT USE_SYSTEM_XZ)
 
     ExternalProject_Add(
         xz-EXTERNAL
-        URL https://netcologne.dl.sourceforge.net/project/lzmautils/xz-5.2.3.tar.gz
-        URL_HASH SHA512=a5eb4f707cf31579d166a6f95dbac45cf7ea181036d1632b4f123a4072f502f8d57cd6e7d0588f0bf831a07b8fc4065d26589a25c399b95ddcf5f73435163da6
+        URL https://netcologne.dl.sourceforge.net/project/lzmautils/xz-5.2.5.tar.gz
+        URL_HASH SHA512=7443674247deda2935220fbc4dfc7665e5bb5a260be8ad858c8bd7d7b9f0f868f04ea45e62eb17c0a5e6a2de7c7500ad2d201e2d668c48ca29bd9eea5a73a3ce
         CONFIGURE_COMMAND CC=${CC} CXX=${CXX} CFLAGS=${CFLAGS} CPPFLAGS=${CPPFLAGS} LDFLAGS=${LDFLAGS} <SOURCE_DIR>/configure --with-pic --disable-shared --enable-static --prefix=<INSTALL_DIR> --libdir=<INSTALL_DIR>/lib ${EXTRA_CONFIGURE_FLAGS} --disable-xz --disable-xzdec
         BUILD_COMMAND ${MAKE}
         INSTALL_COMMAND ${MAKE} install

--- a/include/appimage/appimage_shared.h
+++ b/include/appimage/appimage_shared.h
@@ -12,8 +12,8 @@ extern "C" {
  */
 bool appimage_get_elf_section_offset_and_length(const char* fname, const char* section_name, unsigned long* offset, unsigned long* length);
 
-int appimage_print_hex(char* fname, unsigned long offset, unsigned long length);
-int appimage_print_binary(char* fname, unsigned long offset, unsigned long length);
+int appimage_print_hex(const char* fname, unsigned long offset, unsigned long length);
+int appimage_print_binary(const char* fname, unsigned long offset, unsigned long length);
 
 /*
  * Creates hexadecimal representation of a byte array. Allocates a new char array (string) with the correct size that

--- a/src/libappimage_shared/elf.c
+++ b/src/libappimage_shared/elf.c
@@ -185,7 +185,7 @@ char* read_file_offset_length(const char* fname, unsigned long offset, unsigned 
 	return buffer;
 }
 
-int appimage_print_hex(char* fname, unsigned long offset, unsigned long length) {
+int appimage_print_hex(const char* fname, unsigned long offset, unsigned long length) {
 	char* data;
 	if ((data = read_file_offset_length(fname, offset, length)) == NULL) {
 		return 1;
@@ -202,7 +202,7 @@ int appimage_print_hex(char* fname, unsigned long offset, unsigned long length) 
 	return 0;
 }
 
-int appimage_print_binary(char* fname, unsigned long offset, unsigned long length) {
+int appimage_print_binary(const char* fname, unsigned long offset, unsigned long length) {
 	char* data;
 	if ((data = read_file_offset_length(fname, offset, length)) == NULL) {
 		return 1;

--- a/tests/libappimage/legacy/test_libappimage.cpp
+++ b/tests/libappimage/legacy/test_libappimage.cpp
@@ -303,7 +303,7 @@ bool test_compare_bytes(const char* buf1, const char* buf2, int size) {
 
 TEST_F(LibAppImageTest, appimage_type2_digest_md5) {
     char digest[16];
-    char expectedDigest[] = {-75, -71, 106, -93, 122, 114, 7, 127, -40, 10, -115, -82, -73, 115, -19, 1};
+    char expectedDigest[] = {'\xb5', '\xb9', '\x6a', '\xa3', '\x7a', '\x72', '\x7', '\x7f', '\xd8', '\xa', '\x8d', '\xae', '\xb7', '\x73', '\xed', '\x1'};
 
     EXPECT_TRUE(appimage_type2_digest_md5(appImage_type_2_file_path.c_str(), digest));
     EXPECT_PRED3(test_compare_bytes, digest, expectedDigest, 16);

--- a/tests/libappimage/legacy/test_shared.cpp
+++ b/tests/libappimage/legacy/test_shared.cpp
@@ -20,7 +20,7 @@ using namespace std;
 class LibAppImageSharedTest : public TestBase {};
 
 
-static bool test_strcmp(char* a, char* b) {
+static bool test_strcmp(const char* a, const char* b) {
     return strcmp(a, b) == 0;
 }
 


### PR DESCRIPTION
In preparation for Elbrus port, I made some small patches.

LCC forces some warnings to errors so I had to fix them.
XZ 5.2.5 has upgraded autotools, so it compiles for Elbrus too.