### PR TITLE
Respect BUILD_SHARED_LIBS for libappimage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 
 include(cmake/reproducible_builds.cmake)
 
+option(BUILD_SHARED_LIBS "Enable shared library build" On)
 option(LIBAPPIMAGE_DESKTOP_INTEGRATION_ENABLED "Enable desktop integration functions" On)
 option(LIBAPPIMAGE_THUMBNAILER_ENABLED "Enable thumbnailer functions" On)
 option(LIBAPPIMAGE_STANDALONE "Statically embbed dependencies" Off)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -39,11 +39,6 @@ if(BUILD_TESTING)
 endif()
 
 if (NOT LIBAPPIMAGE_SHARED_ONLY)
-    import_pkgconfig_target(TARGET_NAME liblzma PKGCONFIG_TARGET liblzma)
-
-    import_pkgconfig_target(TARGET_NAME libzstd PKGCONFIG_TARGET libzstd)
-
-
     # as distros don't provide suitable squashfuse and squashfs-tools, those dependencies are bundled in, can, and should
     # be used from this repository for AppImageKit
     # for distro packaging, it can be linked to an existing package just fine
@@ -51,6 +46,9 @@ if (NOT LIBAPPIMAGE_SHARED_ONLY)
 
     if(NOT USE_SYSTEM_SQUASHFUSE)
         message(STATUS "Downloading and building squashfuse")
+
+        import_pkgconfig_target(TARGET_NAME liblzma PKGCONFIG_TARGET liblzma)
+        import_pkgconfig_target(TARGET_NAME libzstd PKGCONFIG_TARGET libzstd)
 
         # Check if fuse is installed to provide early error reports
         import_pkgconfig_target(TARGET_NAME libfuse PKGCONFIG_TARGET fuse)

--- a/cmake/imported_dependencies.cmake.in
+++ b/cmake/imported_dependencies.cmake.in
@@ -1,4 +1,5 @@
 include(${CMAKE_CURRENT_LIST_DIR}/scripts.cmake)
+include(CMakeFindDependencyMacro)
 
 # the names of the targets need to differ from the library filenames
 # this is especially an issue with libcairo, where the library is called libcairo
@@ -10,4 +11,15 @@ if(NOT @LIBAPPIMAGE_SHARED_ONLY@)
     import_pkgconfig_target(TARGET_NAME libzlib PKGCONFIG_TARGET zlib)
     import_pkgconfig_target(TARGET_NAME libcairo PKGCONFIG_TARGET cairo)
     import_pkgconfig_target(TARGET_NAME librsvg PKGCONFIG_TARGET librsvg-2.0)
+
+    if(NOT @BUILD_SHARED_LIBS@)
+        if (@USE_SYSTEM_SQUASHFUSE@)
+            import_pkgconfig_target(TARGET_NAME libsquashfuse PKGCONFIG_TARGET squashfuse)
+        endif()
+        import_find_pkg_target(libarchive LibArchive LibArchive)
+        find_dependency(Boost 1.53.0)
+        if (@USE_SYSTEM_XDGUTILS@)
+            find_dependency(XdgUtils COMPONENTS DesktopEntry BaseDir)
+        endif()
+    endif()
 endif()

--- a/cmake/scripts.cmake
+++ b/cmake/scripts.cmake
@@ -99,9 +99,15 @@ function(import_pkgconfig_target)
 
     find_package(PkgConfig REQUIRED)
 
-    set(type "shared")
+    # decide type based on BUILD_SHARED_LIBS unless overridden by STATIC
     if(IMPORT_PKGCONFIG_TARGET_STATIC)
         set(type "static")
+    else()
+        if(BUILD_SHARED_LIBS)
+            set(type "shared")
+        else()
+            set(type "static")
+        endif()
     endif()
 
     message(STATUS "Importing target ${IMPORT_PKGCONFIG_TARGET_TARGET_NAME} via pkg-config (${IMPORT_PKGCONFIG_TARGET_PKGCONFIG_TARGET}, ${type})")
@@ -116,7 +122,7 @@ function(import_pkgconfig_target)
         return()
     endif()
 
-    if(IMPORT_PKGCONFIG_TARGET_STATIC)
+    if(type STREQUAL "static")
         set(prefix ${IMPORT_PKGCONFIG_TARGET_TARGET_NAME}-IMPORTED_STATIC)
     else()
         set(prefix ${IMPORT_PKGCONFIG_TARGET_TARGET_NAME}-IMPORTED)

--- a/src/libappimage/CMakeLists.txt
+++ b/src/libappimage/CMakeLists.txt
@@ -14,49 +14,57 @@ if(LIBAPPIMAGE_DESKTOP_INTEGRATION_ENABLED)
     add_subdirectory(desktop_integration)
     list(APPEND libappimage_sources "$<TARGET_OBJECTS:appimage_desktop_integration>")
 endif()
+if(BUILD_SHARED_LIBS)
+    add_library(libappimage SHARED ${libappimage_sources} libappimage_legacy.cpp)
 
-add_library(libappimage_static STATIC ${libappimage_sources})
-add_library(libappimage SHARED ${libappimage_sources} libappimage_legacy.cpp)
+    # For shared libraries, link privately to xdg-basedir
+    target_link_libraries(libappimage PRIVATE xdg-basedir)
+else()
+    add_library(libappimage STATIC ${libappimage_sources})
+    # For static libraries, include xdg-basedir object files directly to avoid export issues
+    target_sources(libappimage PRIVATE $<TARGET_OBJECTS:xdg-basedir>)
+    get_target_property(XDG_BASEDIR_INCLUDES xdg-basedir INTERFACE_INCLUDE_DIRECTORIES)
+    if(XDG_BASEDIR_INCLUDES)
+        target_include_directories(libappimage PRIVATE ${XDG_BASEDIR_INCLUDES})
+    endif()
+endif()
 
 configure_file(config.h.in ${PROJECT_BINARY_DIR}/generated-headers/appimage/config.h)
 
-foreach(target libappimage libappimage_static)
-    configure_libappimage_module(${target})
-    target_link_libraries(
-        ${target}
-        PRIVATE libarchive
-        PRIVATE xdg-basedir
-        PRIVATE XdgUtils::DesktopEntry
-        PRIVATE XdgUtils::BaseDir
-        PRIVATE libappimage_hashlib
-        # not linking publicly to squashfuse as headers are not needed when using libappimage
-        # unit tests etc., which use squashfuse directly, must link to it explicitly
-        PRIVATE libsquashfuse
-        PRIVATE Boost::boost
-        PUBLIC libappimage_shared
-        PUBLIC pthread
-        PRIVATE libgio
-        PUBLIC libcairo
-        PUBLIC librsvg
-        PUBLIC dl
-    )
-    message(STATUS "IMAGE_MANIPULATION_BACKEND_LIBS ${IMAGE_MANIPULATION_BACKEND_LIBS}")
-    if(LIBAPPIMAGE_STANDALONE)
-        target_link_libraries(${target} PRIVATE -static-libgcc -static-libstdc++)
-    endif()
+configure_libappimage_module(libappimage)
 
-    target_include_directories(
-        ${target}
-        PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-        PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/generated-headers>
-    )
+target_link_libraries(
+    libappimage
+    PRIVATE libarchive
+    PRIVATE XdgUtils::DesktopEntry
+    PRIVATE XdgUtils::BaseDir
+    PRIVATE libappimage_hashlib
+    # not linking publicly to squashfuse as headers are not needed when using libappimage
+    # unit tests etc., which use squashfuse directly, must link to it explicitly
+    PRIVATE libsquashfuse
+    PRIVATE Boost::boost
+    PUBLIC libappimage_shared
+    PUBLIC pthread
+    PRIVATE libgio
+    PUBLIC libcairo
+    PUBLIC librsvg
+    PUBLIC dl
+)
+message(STATUS "IMAGE_MANIPULATION_BACKEND_LIBS ${IMAGE_MANIPULATION_BACKEND_LIBS}")
+if(LIBAPPIMAGE_STANDALONE)
+    target_link_libraries(libappimage PRIVATE -static-libgcc -static-libstdc++)
+endif()
 
-    set_property(TARGET libappimage PROPERTY PUBLIC_HEADER ${libappimage_public_header})
+target_include_directories(
+    libappimage
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/generated-headers>
+)
 
-    set_property(TARGET libappimage PROPERTY VERSION ${libappimage_VERSION})
-    set_property(TARGET libappimage PROPERTY SOVERSION ${libappimage_SOVERSION})
-endforeach()
+set_property(TARGET libappimage PROPERTY PUBLIC_HEADER ${libappimage_public_header})
 
+set_property(TARGET libappimage PROPERTY VERSION ${libappimage_VERSION})
+set_property(TARGET libappimage PROPERTY SOVERSION ${libappimage_SOVERSION})
 
 # install libappimage
 install(


### PR DESCRIPTION
Updates the build setup to respect the `BUILD_SHARED_LIBS` flag when building libappimage.

- If `BUILD_SHARED_LIBS` is `On`, builds a shared lib and links to xdg-basedir
- If `Off`, builds a static lib and embeds xdg-basedir object files directly

Also removes the hardcoded `libappimage_static` target.

Defaults to shared build.

- Added privately linked dependencies to `cmake/imported_dependencies.cmake` used when building statically.